### PR TITLE
Implement TODO tasks in inventory

### DIFF
--- a/packages/contracts/src/CardsCollection.sol
+++ b/packages/contracts/src/CardsCollection.sol
@@ -22,6 +22,7 @@ struct Card {
     uint256 id;
     Lore lore;
     Stats stats;
+    uint32 cardTypeID;
 }
 
 error Unauthorized();
@@ -36,6 +37,7 @@ contract CardsCollection is ERC721, Ownable {
 
     mapping(uint256 => Lore) public lore;
     mapping(uint256 => Stats) private stats_;
+    mapping(uint256 => uint32) public cardType;
 
     // Airdrop manager.
     address public airdrop;
@@ -69,6 +71,8 @@ contract CardsCollection is ERC721, Ownable {
         _safeMint(to, tokenID, "");
         stats_[tokenID] = Stats(attack, defense);
         lore[tokenID] = Lore(name, flavor, URL);
+        // NOTE(nonso): `tokenID` serves as a placeholder for the cardType ID
+        cardType[tokenID] = uint32(tokenID);
     }
 
     function stats(uint256 card) external view returns (Stats memory) {
@@ -81,6 +85,10 @@ contract CardsCollection is ERC721, Ownable {
     }
 
     function getCard(uint256 card) external view returns (Card memory) {
-        return Card(card, lore[card], stats_[card]);
+        return Card(card, lore[card], stats_[card], cardType[card]);
+    }
+ 
+    function getCardType(uint256 card) external view returns(uint32){
+        return cardType[card];
     }
 }

--- a/packages/contracts/src/CardsCollection.sol
+++ b/packages/contracts/src/CardsCollection.sol
@@ -87,8 +87,4 @@ contract CardsCollection is ERC721, Ownable {
     function getCard(uint256 card) external view returns (Card memory) {
         return Card(card, lore[card], stats_[card], cardType[card]);
     }
- 
-    function getCardType(uint256 card) external view returns(uint32){
-        return cardType[card];
-    }
 }

--- a/packages/contracts/src/Game.sol
+++ b/packages/contracts/src/Game.sol
@@ -1035,7 +1035,7 @@ contract Game {
 
     // Returns true if a `player` is currently in an active game
     // This works because players cannot participate in multiple games simultaneously
-    function playerActive(address player) external view returns(bool){
+    function playerActive(address player) external view returns (bool) {
         return inGame[player] != 0;
     }
 

--- a/packages/contracts/src/Game.sol
+++ b/packages/contracts/src/Game.sol
@@ -1032,4 +1032,12 @@ contract Game {
     }
 
     // ---------------------------------------------------------------------------------------------
+
+    // Returns true if a `player` is currently in an active game
+    // This works because players cannot participate in multiple games simultaneously
+    function playerActive(address player) external view returns(bool){
+        return inGame[player] != 0;
+    }
+
+    // ---------------------------------------------------------------------------------------------
 }

--- a/packages/contracts/src/Inventory.sol
+++ b/packages/contracts/src/Inventory.sol
@@ -170,7 +170,7 @@ contract Inventory is Ownable {
 
     // Transfers a card of the sender to the inventory, mints a soulbound inventory card to the
     // sender in return.
-    function addCard(address player, uint256 cardID) external delegated(player) notInGame(player) {
+    function addCard(address player, uint256 cardID) external delegated(player) {
         originalCardsCollection.transferFrom(player, address(this), cardID);
         inventoryCardsCollection.mint(player, cardID);
         emit CardAdded(player, cardID);
@@ -223,9 +223,9 @@ contract Inventory is Ownable {
     // ---------------------------------------------------------------------------------------------
 
     // Remove the given deck for the sender, leaving the deck at the given ID empty.
-    function removeDeck(address player, uint8 deckID) 
-        external 
-        delegated(player) 
+    function removeDeck(address player, uint8 deckID)
+        external
+        delegated(player)
         exists(player, deckID)
         notInGame(player)
     {
@@ -304,18 +304,16 @@ contract Inventory is Ownable {
         }
 
         // Sort cards according to type.
-        uint256[] memory sortedCards = Utils.sort(
-            getCardType(deck.cards)
-        );
+        uint256[] memory sortedCards = Utils.sort(getCardTypes(deck.cards));
 
         uint256 cardCopies;
         uint256 prevCardType;
         for (uint256 i = 0; i < deckLength; ++i) {
             uint256 cardType = sortedCards[i];
-            if (cardType == prevCardType){ 
+            if (cardType == prevCardType) {
                 cardCopies++;
                 // check that each card does not exceed its maximum amount of copies.
-                if (cardCopies > MAX_CARD_COPY){
+                if (cardCopies > MAX_CARD_COPY) {
                     revert CardExceedsMaxCopy(cardType);
                 }
             } else {
@@ -348,11 +346,11 @@ contract Inventory is Ownable {
 
     // ---------------------------------------------------------------------------------------------
 
-    function getCardType(uint256[] memory cardIDArr) public view returns(uint256[] memory){
+    function getCardTypes(uint256[] memory cardIDArr) public view returns (uint256[] memory) {
         uint256 len = cardIDArr.length;
         uint256[] memory cardTypeArr = new uint256[](len);
-        for(uint256 i = 0; i < len; i++){
-            cardTypeArr[i] = uint256(originalCardsCollection.getCardType(cardIDArr[i]));
+        for (uint256 i = 0; i < len; i++) {
+            cardTypeArr[i] = uint256(originalCardsCollection.cardType(cardIDArr[i]));
         }
         return cardTypeArr;
     }

--- a/packages/contracts/src/lib/Utils.sol
+++ b/packages/contracts/src/lib/Utils.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// https://gist.github.com/subhodi/b3b86cc13ad2636420963e692a4d896f
+library Utils {
+    function sort(uint[] memory data) public view returns(uint[] memory) {
+       quickSort(data, int(0), int(data.length - 1));
+       return data;
+    }
+    
+    function quickSort(uint[] memory arr, int left, int right) internal view {
+        int i = left;
+        int j = right;
+        if(i==j) return;
+        uint pivot = arr[uint(left + (right - left) / 2)];
+        while (i <= j) {
+            while (arr[uint(i)] < pivot) i++;
+            while (pivot < arr[uint(j)]) j--;
+            if (i <= j) {
+                (arr[uint(i)], arr[uint(j)]) = (arr[uint(j)], arr[uint(i)]);
+                i++;
+                j--;
+            }
+        }
+        if (left < j)
+            quickSort(arr, left, j);
+        if (i < right)
+            quickSort(arr, i, right);
+    }
+}

--- a/packages/contracts/src/test/Inventory.t.sol
+++ b/packages/contracts/src/test/Inventory.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.0;
+
+import {CardsCollection} from "../CardsCollection.sol";
+import {DeckAirdrop} from "../DeckAirdrop.sol";
+import {Inventory} from "../Inventory.sol";
+
+import {Test} from "forge-std/Test.sol";
+import {Deploy} from "../deploy/Deploy.s.sol";
+
+contract InventoryTest is Test {
+    Deploy private deployment;
+    CardsCollection private cardsCollection;
+    Inventory private inventory;
+    DeckAirdrop private airdrop;
+
+    address private constant player1 = 0x00000000000000000000000000000000DeaDBeef;
+    address private constant player2 = 0x00000000000000000000000000000000deAdBAbE;
+
+    function setUp() public {
+        deployment = new Deploy();
+        deployment.dontLog();
+        deployment.run();
+
+        cardsCollection = deployment.cardsCollection();
+        inventory = deployment.inventory();
+        airdrop = deployment.airdrop();
+
+        vm.prank(player1);
+        airdrop.claimAirdrop();
+    }
+
+    // expect revert if player's deck contains a card with more than `MAX_CARD_COPY` copies.
+    function testCheckDeckExceedsMaxCopy() public {
+        uint8 deckId = 0;
+        uint256 randomCard = inventory.getDeck(player1, deckId)[2];
+
+        // increase card `randomCard` copy to 4
+        vm.startPrank(player1);
+        inventory.addCardToDeck(player1, deckId, randomCard);
+        inventory.addCardToDeck(player1, deckId, randomCard);
+        inventory.addCardToDeck(player1, deckId, randomCard);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Inventory.CardExceedsMaxCopy.selector, randomCard)
+        );
+
+        inventory.checkDeck(player1, deckId);
+    }
+
+    // expect revert if player's deck contains a card they don't own.
+    function testCheckDeckOnlyInventoryCards() public {
+        
+        // mint card `randomMint` to player2.
+        vm.startPrank(cardsCollection.airdrop());
+        uint256 randomMint = cardsCollection.mint(player2, "Horrible Gremlin", "", "", 1, 1);
+
+        // add card `randomMint` to inventory.
+        changePrank(player2);
+        inventory.addCard(player2, randomMint);
+
+        uint8 deckId = 0;
+
+        // add card `randomMint` to player2's deck.
+        changePrank(player1);
+        inventory.addCardToDeck(player1, deckId, randomMint);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Inventory.CardNotInInventory.selector, randomMint)
+        );
+
+        inventory.checkDeck(player1, deckId);
+    }
+}

--- a/packages/contracts/src/test/Inventory.t.sol
+++ b/packages/contracts/src/test/Inventory.t.sol
@@ -52,18 +52,27 @@ contract InventoryTest is Test {
         vm.startPrank(cardsCollection.airdrop());
         uint256 randomMint = cardsCollection.mint(player2, "Horrible Gremlin", "", "", 1, 1);
 
-        // add card `randomMint` to inventory.
-        changePrank(player2);
-        inventory.addCard(player2, randomMint);
-
         uint8 deckId = 0;
 
-        // add card `randomMint` to player1's deck.
+        // scenario 1: Add Non-Inventory card to deck.
+        // player1 adds a card that has has not being staked in the inventory to its deck
         changePrank(player1);
+        // add card `randomMint` to inventory.
         inventory.addCardToDeck(player1, deckId, randomMint);
+        vm.expectRevert("ERC721: invalid token ID");
+        inventory.checkDeck(player1, deckId);
 
+        // scenario 2: Add Inventory card to deck.
+        // player1 adds a card that has being staked in the inventory to their deck but
+        // they don't own it.
+        changePrank(player2);
+        // add card `randomMint` to inventory.
+        inventory.addCard(player2, randomMint);
+
+        changePrank(player1);
+        // add card `randomMint` to player1's deck.
+        inventory.addCardToDeck(player1, deckId, randomMint);
         vm.expectRevert(abi.encodeWithSelector(Inventory.CardNotInInventory.selector, randomMint));
-
         inventory.checkDeck(player1, deckId);
     }
 }

--- a/packages/contracts/src/test/Inventory.t.sol
+++ b/packages/contracts/src/test/Inventory.t.sol
@@ -35,22 +35,19 @@ contract InventoryTest is Test {
         uint8 deckId = 0;
         uint256 randomCard = inventory.getDeck(player1, deckId)[2];
 
-        // increase card `randomCard` copy to 4
+        // increase card `randomCard` copies to 4
         vm.startPrank(player1);
         inventory.addCardToDeck(player1, deckId, randomCard);
         inventory.addCardToDeck(player1, deckId, randomCard);
         inventory.addCardToDeck(player1, deckId, randomCard);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(Inventory.CardExceedsMaxCopy.selector, randomCard)
-        );
+        vm.expectRevert(abi.encodeWithSelector(Inventory.CardExceedsMaxCopy.selector, randomCard));
 
         inventory.checkDeck(player1, deckId);
     }
 
     // expect revert if player's deck contains a card they don't own.
     function testCheckDeckOnlyInventoryCards() public {
-        
         // mint card `randomMint` to player2.
         vm.startPrank(cardsCollection.airdrop());
         uint256 randomMint = cardsCollection.mint(player2, "Horrible Gremlin", "", "", 1, 1);
@@ -61,13 +58,11 @@ contract InventoryTest is Test {
 
         uint8 deckId = 0;
 
-        // add card `randomMint` to player2's deck.
+        // add card `randomMint` to player1's deck.
         changePrank(player1);
         inventory.addCardToDeck(player1, deckId, randomMint);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(Inventory.CardNotInInventory.selector, randomMint)
-        );
+        vm.expectRevert(abi.encodeWithSelector(Inventory.CardNotInInventory.selector, randomMint));
 
         inventory.checkDeck(player1, deckId);
     }


### PR DESCRIPTION
## Context (Problem, Motivation, Solution)
- Prevent card deck from being modified in the inventory during a game
- Limit maximum number of card copies in a deck to three

Link related issues!
https://github.com/norswap/0xFable/blob/master/docs/architecture.md#cards-and-inventory

## Describe Your Changes
- Added a modifier `notInGame()` to prevent players from modifying card deck while participating in a game
- Implement `checkDeck()` to check if a player possesses more than three copies of  a card in a deck
## Checklist

- [x] I have performed a self-review of my code
- [x] I ran `make lint` and fixed resulting issues
- [x] I ran the relevant tests and they all pass
- [x] I wrote tests for my new features, or added regression tests for the bug I fixed

## Testing
basic tests [here](https://github.com/0xNONSO/0xFable/blob/master/packages/contracts/src/test/Inventory.t.sol)