### PR TITLE
Add timeout to proof generation, and enable cancelling proofs

### DIFF
--- a/packages/circuits/src/proofs/DrawHand.circom
+++ b/packages/circuits/src/proofs/DrawHand.circom
@@ -26,7 +26,7 @@ include "../../node_modules/circomlib/circuits/mimcsponge.circom";
  *   (replacing them with cards from the back of the deck and shrinking the deck)
  * - `salt` is the player's secret salt
  *
- * 20785 Plonk constraints.
+ * 23,546 Plonk constraints.
  */
 template DrawHand(elementSize, initialHandSize) {
 

--- a/packages/webapp/src/actions/drawCard.ts
+++ b/packages/webapp/src/actions/drawCard.ts
@@ -23,6 +23,7 @@ import { GameStep, PrivateInfo } from "src/store/types"
 import { FAKE_PROOF, proveInWorker, SHOULD_GENERATE_PROOFS } from "src/utils/zkproofs"
 import { bigintToHexString, parseBigInt } from "src/utils/js-utils"
 import { mimcHash } from "src/utils/hashing"
+import { DRAW_CARD_PROOF_TIMEOUT } from "src/constants"
 
 // =================================================================================================
 
@@ -45,7 +46,7 @@ export async function drawCard(args: DrawCardArgs): Promise<boolean> {
     return await drawCardImpl(args)
   } catch (err) {
     args.setLoading(null)
-    return defaultErrorHandling("joinGame", err)
+    return defaultErrorHandling("drawCard", err)
   }
 }
 
@@ -85,16 +86,6 @@ async function drawCardImpl(args: DrawCardArgs): Promise<boolean> {
   const newHandRoot: HexString = `0x${bigintToHexString(mimcHash(handRootInputs), 32)}`
 
   const cards = getCards()!
-  console.dir({
-    cards,
-    selectedCard,
-    deckIndexes: privateInfo.deckIndexes,
-    handIndexes: privateInfo.handIndexes,
-    deckSize,
-    newHand,
-    newDeck,
-    newHandLastIndex,
-  })
   console.log(`drew card ${cards[selectedCard]}`)
 
   args.setLoading("Generating draw proof ...")
@@ -141,7 +132,7 @@ async function drawCardImpl(args: DrawCardArgs): Promise<boolean> {
         hand: packCards(privateInfo.handIndexes),
         newDeck: packCards(newDeck),
         newHand: packCards(newHand)
-    })))
+    }, DRAW_CARD_PROOF_TIMEOUT)))
 
   checkFresh(await freshWrap(
     contractWriteThrowing({

--- a/packages/webapp/src/actions/errors.ts
+++ b/packages/webapp/src/actions/errors.ts
@@ -78,7 +78,7 @@ export function defaultErrorHandling(actionName: string, err: unknown): false {
 
   if (err instanceof ProofTimeoutError) {
     setError({
-      title: "ZK proof timed out.",
+      title: "ZK proof generation timed out.",
       message: "Please try again.",
       buttons: [DISMISS_BUTTON]
     })

--- a/packages/webapp/src/actions/joinGame.ts
+++ b/packages/webapp/src/actions/joinGame.ts
@@ -34,9 +34,15 @@ import {
   getPrivateInfo
 } from "src/store/read"
 import { FetchedGameData, GameStatus, PlayerData, PrivateInfo } from "src/store/types"
-import { SHOULD_GENERATE_PROOFS, FAKE_PROOF, ProofOutput, proveInWorker } from "src/utils/zkproofs"
+import {
+  SHOULD_GENERATE_PROOFS,
+  FAKE_PROOF,
+  ProofOutput,
+  proveInWorker
+} from "src/utils/zkproofs"
 import { NUM_CARDS_FOR_PROOF } from "src/game/constants"
 import { packCards } from "src/game/fableProofs"
+import { DRAW_HAND_PROOF_TIMEOUT } from "src/constants"
 
 // =================================================================================================
 
@@ -209,7 +215,7 @@ async function generateDrawInitialHandProof(
     salt: privateInfo.salt,
     deck: packCards(privateInfo.deckIndexes),
     hand: packCards(privateInfo.handIndexes)
-  })
+  }, DRAW_HAND_PROOF_TIMEOUT)
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/packages/webapp/src/components/card.tsx
+++ b/packages/webapp/src/components/card.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import Image from "next/image"
 import { playCard } from "src/actions/playCard"
 import { Address } from "src/chain"
+import { CancellationHandler } from "src/components/lib/loadingModal"
 
 // quick fix for hackathon
 const cards = [
@@ -98,6 +99,7 @@ export const Card = ({
   className,
   handHovered,
   setLoading,
+  cancellationHandler
 }: {
   // TODO id has a double role as ID and card index in hand
   id: number
@@ -106,6 +108,7 @@ export const Card = ({
   className?: string
   handHovered?: boolean
   setLoading: (label: string | null) => void
+  cancellationHandler: CancellationHandler
 }) => {
   // const [ , addToBoard ] = useAtom(store.addToBoard)
   const [isDetailsVisible, setIsDetailsVisible] = useState<boolean>(false)
@@ -123,7 +126,8 @@ export const Card = ({
           gameID,
           playerAddress,
           cardIndexInHand: id,
-          setLoading
+          setLoading,
+          cancellationHandler
         })
       }}
       onMouseEnter={() => setCardHover(true)}

--- a/packages/webapp/src/components/hand.tsx
+++ b/packages/webapp/src/components/hand.tsx
@@ -3,15 +3,18 @@ import { AiOutlineLeft, AiOutlineRight } from "react-icons/ai"
 import useScrollBox from "../hooks/useScrollBox"
 import { Card } from "./card"
 import * as store from "src/store/hooks"
+import { CancellationHandler } from "src/components/lib/loadingModal"
 
 const Hand = ({
   cards,
   className,
   setLoading,
+  cancellationHandler
 }: {
   cards?: bigint[] | null
   className?: string
   setLoading: (label: string | null) => void
+  cancellationHandler: CancellationHandler
 }) => {
   const [isFocused, setIsFocused] = useState<boolean>(false)
 
@@ -34,6 +37,7 @@ const Hand = ({
             className="transitional-all duration-200 hover:scale-[100%] hover:border-yellow-500"
             handHovered={isFocused}
             setLoading={setLoading}
+            cancellationHandler={cancellationHandler}
           />
         </div>
       )

--- a/packages/webapp/src/components/lib/loadingModal.tsx
+++ b/packages/webapp/src/components/lib/loadingModal.tsx
@@ -1,7 +1,35 @@
-import { ReactNode } from "react"
+import { ReactNode, useCallback } from "react"
 
 import { ModalTitle, Spinner } from "src/components/lib/modalElements"
 import { Modal, ModalController } from "src/components/lib/modal"
+
+// =================================================================================================
+
+/**
+ * This class is used to register and deregister cancellation callbacks, and call them once the
+ * modal is explicitly cancelled by the user.
+ *
+ * The recommended way to obtain an instance of this class is via the {@link
+ * module:hooks/useCancellationHandler#useCancellationHandler} hook.
+ */
+export class CancellationHandler {
+  private callbacks: (() => void)[] = []
+
+  /** Register a callback to be called when the modal is cancelled. */
+  register = (callback: () => void) => {
+    this.callbacks.push(callback)
+  }
+
+  /** Deregister a callback. */
+  deregister = (callback: () => void) => {
+    this.callbacks = this.callbacks.filter(cb => cb !== callback)
+  }
+
+  /** Call all registered callbacks. */
+  cancel = () => {
+    this.callbacks.forEach(cb => cb())
+  }
+}
 
 // =================================================================================================
 
@@ -16,6 +44,11 @@ export type LoadingModalProps = {
    * be dismissed.
    */
   setLoading: (_: string|null) => void
+  /**
+   * A cancellation handler that can be used to register callbacks to be called when the modal is
+   * cancelled via its "cancel" button.
+   */
+  cancellationHandler?: CancellationHandler
   children?: ReactNode
 }
 
@@ -24,6 +57,9 @@ export type LoadingModalProps = {
 /**
  * A modal for displaying loading screens, for use by components that are not themselves modals, as
  * it wraps {@link LoadingModalContent}.
+ *
+ * The display of this modal should be controlled via conditional rendering in the parent component,
+ * bsed on whether the loading state is populated or not.
  */
 export const LoadingModal = (props: LoadingModalProps & { ctrl: ModalController }) => {
 
@@ -35,22 +71,26 @@ export const LoadingModal = (props: LoadingModalProps & { ctrl: ModalController 
 // =================================================================================================
 
 /**
- * This is a modal for displaying loading screens, for use by components that are not themselves
- * modals, and where the display of the modal is meant to be controlled via conditional rendering in
- * the parent component.
+ * This is modal content for displaying loading screens. The parent of this component should be a
+ * modal.
  *
- * NOTE: The main benefit of this is avoiding the `useCheckboxModal` hook in the parent component.
- * I'm not sure it's worth the abstraction?
+ * The display of this content should be controlled via conditional rendering in the parent or
+ * grandparent, depending on whether the loading state is populated or not.
  */
 export const LoadingModalContent =
-  ({ cancellable = true, loading, setLoading, children }: LoadingModalProps) => {
+  ({ cancellable = true, loading, setLoading, cancellationHandler, children }: LoadingModalProps) => {
+
+  const cancel = useCallback(() => {
+    setLoading(null)
+    cancellationHandler?.cancel()
+  }, [setLoading, cancellationHandler])
 
   return <>
     <ModalTitle>{loading}</ModalTitle>
     {children}
     <Spinner />
     {cancellable && <div className="flex justify-center">
-      <button className="btn center" onClick={() => setLoading(null)}>
+      <button className="btn center" onClick={cancel}>
         Cancel
       </button>
     </div>}

--- a/packages/webapp/src/components/modals/createGameModal.tsx
+++ b/packages/webapp/src/components/modals/createGameModal.tsx
@@ -12,6 +12,7 @@ import * as store from "src/store/hooks"
 import { joinGame, reportInconsistentGameState } from "src/actions"
 import { GameStatus } from "src/store/types"
 import { navigate } from "src/utils/navigate"
+import { useCancellationHandler } from "src/hooks/useCancellationHandler"
 
 // =================================================================================================
 
@@ -92,6 +93,8 @@ const CreateGameModalContent = ({ ctrl }: { ctrl: ModalController }) => {
     }
   })
 
+  const cancellationHandler = useCancellationHandler(loading)
+
   const join = async () => {
     if (gameID === null || playerAddress === null)
       return reportInconsistentGameState("Not tracking a game or player disconnected.")
@@ -99,7 +102,8 @@ const CreateGameModalContent = ({ ctrl }: { ctrl: ModalController }) => {
     const success = await joinGame({
       gameID,
       playerAddress,
-      setLoading
+      setLoading,
+      cancellationHandler
     })
 
     if (success)
@@ -132,7 +136,12 @@ const CreateGameModalContent = ({ ctrl }: { ctrl: ModalController }) => {
 
   // -----------------------------------------------------------------------------------------------
 
-  if (loading) return <LoadingModalContent loading={loading} setLoading={setLoading} />
+  if (loading)
+    return <LoadingModalContent
+      loading={loading}
+      setLoading={setLoading}
+      cancellationHandler={cancellationHandler}
+    />
 
   if (!created) return <>
     <ModalTitle>Create Game</ModalTitle>

--- a/packages/webapp/src/components/modals/joinGameModal.tsx
+++ b/packages/webapp/src/components/modals/joinGameModal.tsx
@@ -1,6 +1,6 @@
 import debounce from "lodash/debounce"
 import { useRouter } from "next/router"
-import { useEffect, useMemo, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import { ModalMenuButton, ModalTitle, Spinner } from "src/components/lib/modalElements"
 import { InGameMenuModalContent } from "src/components/modals/inGameMenuModalContent"
 
@@ -13,6 +13,7 @@ import { joinGame, reportInconsistentGameState } from "src/actions"
 import { setError } from "src/store/actions"
 import { GameStatus } from "src/store/types"
 import { navigate } from "src/utils/navigate"
+import { useCancellationHandler } from "src/hooks/useCancellationHandler"
 
 // =================================================================================================
 
@@ -66,6 +67,8 @@ const JoinGameModalContent = ({ ctrl }: { ctrl: ModalController }) => {
   //   game ID. This is fine. Alternatively, we could validate the input game ID and enable the hook
   //   only when the ID is valid.
 
+  const cancellationHandler = useCancellationHandler(loading)
+
   const join = async () => {
     if (inputGameID === null || playerAddress === null)
       return reportInconsistentGameState("Not tracking a game or player disconnected.")
@@ -81,7 +84,8 @@ const JoinGameModalContent = ({ ctrl }: { ctrl: ModalController }) => {
     const success = await joinGame({
       gameID: parsedGameID,
       playerAddress,
-      setLoading
+      setLoading,
+      cancellationHandler
     })
 
     if (success) {
@@ -111,7 +115,12 @@ const JoinGameModalContent = ({ ctrl }: { ctrl: ModalController }) => {
 
   // -----------------------------------------------------------------------------------------------
 
-  if (loading) return <LoadingModalContent loading={loading} setLoading={setLoading} />
+  if (loading)
+    return <LoadingModalContent
+      loading={loading}
+      cancellationHandler={cancellationHandler}
+      setLoading={setLoading}
+    />
 
   if (started) return <InGameMenuModalContent concede={concede} />
 

--- a/packages/webapp/src/constants.ts
+++ b/packages/webapp/src/constants.ts
@@ -6,3 +6,12 @@
 
 export const GIT_REPO = "https://github.com/norswap/0xFable"
 export const GIT_ISSUES = `${GIT_REPO}/issues`
+
+/** Proof generation timeout (in seconds) for the proof of the initial hand. */
+export const DRAW_HAND_PROOF_TIMEOUT = 60
+
+/** Proof generation timeout (in seconds) for the proof of drawing a card. */
+export const DRAW_CARD_PROOF_TIMEOUT = 30
+
+/** Proof generation timeout (in seconds) for the proof of playing a card. */
+export const PLAY_CARD_PROOF_TIMEOUT = 30

--- a/packages/webapp/src/hooks/useCancellationHandler.ts
+++ b/packages/webapp/src/hooks/useCancellationHandler.ts
@@ -1,0 +1,43 @@
+/**
+ * cf. {@link useCancellationHandler}
+ *
+ * @module hooks/useCancellationHandler
+ */
+
+import { CancellationHandler } from "src/components/lib/loadingModal"
+import { useEffect, useRef } from "react"
+
+// =================================================================================================
+
+/**
+ * Return a {@link CancellationHandler} for a {@link LoadingModal}. This hook keeps a cancellation
+ * handler at the ready at all times, and discards the current handler in favour of a new one
+ * whenever the loading state transitions from non-null to null (as this signifies that the current
+ * action has been completed and the current action cannot be cancelled anymore, making the existing
+ * cancellation handlers obsolete).
+ */
+export function useCancellationHandler(loading: string | null): CancellationHandler {
+  const previous = useRef<string | null>(loading)
+  const cancellationHandler = useRef<CancellationHandler | null>(null)
+
+  // If the loading state changes from non-null to null, then discard the old cancellation handler,
+  // and create a new one.
+  if (previous !== null && loading === null) {
+    cancellationHandler.current = new CancellationHandler()
+  }
+
+  // This is only to initialize the very first cancellation handler, and avoid calling the
+  // constructor every time the hook is invoked.
+  if (cancellationHandler.current === null) {
+    cancellationHandler.current = new CancellationHandler()
+  }
+
+  // Update previous value.
+  useEffect(() => {
+    previous.current = loading
+  }, [loading])
+
+  return cancellationHandler.current
+}
+
+// =================================================================================================

--- a/packages/webapp/src/pages/play.tsx
+++ b/packages/webapp/src/pages/play.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import Hand from "src/components/hand"
-import { LoadingModal } from "src/components/lib/loadingModal"
+import { CancellationHandler, LoadingModal } from "src/components/lib/loadingModal"
 import { useModalController } from "src/components/lib/modal"
 import { GameEndedModal } from "src/components/modals/gameEndedModal"
 import { Navbar } from "src/components/navbar"
@@ -20,6 +20,7 @@ import { navigate } from "src/utils/navigate"
 import { drawCard } from "src/actions/drawCard"
 import { endTurn } from "src/actions/endTurn"
 import { currentPlayer, isEndingTurn } from "src/game/misc"
+import { useCancellationHandler } from "src/hooks/useCancellationHandler"
 
 const Play: FablePage = ({ isHydrated }) => {
   const [ gameID, setGameID ] = store.useGameID()
@@ -77,12 +78,15 @@ const Play: FablePage = ({ isHydrated }) => {
   const cantDoThings = gameID === null|| playerAddress === null || gameData === null
     || currentPlayer(gameData) !== playerAddress
 
+  const cancellationHandler = useCancellationHandler(loading)
+
   const doDrawCard = cantDoThings || gameData.currentStep !== GameStep.DRAW
     ? undefined
     : () => drawCard({
         gameID,
         playerAddress,
-        setLoading
+        setLoading,
+        cancellationHandler
       })
 
   const doEndTurn = cantDoThings || !isEndingTurn(gameData.currentStep)
@@ -90,7 +94,7 @@ const Play: FablePage = ({ isHydrated }) => {
     : () => endTurn({
       gameID,
       playerAddress,
-      setLoading
+      setLoading,
     })
 
   useEffect(() => {
@@ -133,6 +137,7 @@ const Play: FablePage = ({ isHydrated }) => {
         <Hand
           cards={playerHand}
           setLoading={setLoading}
+          cancellationHandler={cancellationHandler}
           className="absolute left-0 right-0 mx-auto z-[100] translate-y-1/2 transition-all duration-500 rounded-xl ease-in-out hover:translate-y-0"
         />
         <div className="grid-col-1 relative mx-6 mb-6 grid grow grid-rows-[6]">

--- a/packages/webapp/src/utils/zkproofs/proofs.ts
+++ b/packages/webapp/src/utils/zkproofs/proofs.ts
@@ -1,5 +1,7 @@
 /**
  * Utilities to deal with Circom proofs.
+ *
+ * @module utils/zkproofs/proofs
  */
 
 import { formatTimestamp } from "src/utils/js-utils"


### PR DESCRIPTION
The former is necessary, as sometimes proof generation will run forever (I *believe* this is a snag in snarkjs), while the later is just good practice, right now cancelling has no effect but to dismiss a modal that will come back later.

Note that this is the only time we currently are able (i.e. that we implemented) to meaningfully cancel an action. Cancelling at other times (e.g. when sending transactions) will simply cause the modal to be dismissed and to come back later (or the action to complete). We need to implement this too.